### PR TITLE
Network emulator

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -155,6 +155,10 @@ The task represents one step of a single experiment and contains both the inform
 `interface`: interface where network conditions will be applied.
 `rules`: list of rules that will apply to the previous interface. For more information, visit [tc-netem docs](http://man7.org/linux/man-pages/man8/tc-netem.8.html)
 
+If this task was used, after the experiment `sudo tc qdisc del dev [interface] root` must be run in the machine where
+the network conditions were added in order to clean the rules applied.
+
+If running on remote-runner, make sure to remove the password for sudo.
 
 ## Supported Object Runners and Their Configs
 

--- a/configs/lore_xtransmit_live_network_conditions.json
+++ b/configs/lore_xtransmit_live_network_conditions.json
@@ -1,0 +1,135 @@
+{
+  "collect_results_path": "_experiment_results",
+  "stop_after": 40,
+  "ignore_stop_order": true,
+  "tasks": {
+    "1": {
+      "obj_type": "tshark",
+      "obj_config": {
+        "path": "tshark",
+        "interface": "en0",
+        "port": "4200",
+        "dirpath": "_results"
+      },
+      "runner_type": "local-runner",
+      "runner_config": {},
+      "sleep_after_start": null,
+      "sleep_after_stop": null,
+      "stop_order": null
+    },
+    "2": {
+      "obj_type": "tshark",
+      "obj_config": {
+        "path": "tshark",
+        "interface": "eth0",
+        "port": "4200",
+        "dirpath": "_results"
+      },
+      "runner_type": "remote-runner",
+      "runner_config": {
+        "username": "msharabayko",
+        "host": "40.69.89.21"
+      },
+      "sleep_after_start": null,
+      "sleep_after_stop": null,
+      "stop_order": null
+    },
+    "3": {
+      "obj_type": "netem",
+      "obj_config": {
+        "interface": "en0",
+        "rules": [
+          "delay 100ms",
+          "loss 10"
+        ]
+      },
+      "runner_type": "local-runner",
+      "runner_config": {},
+      "sleep_after_start": null,
+      "sleep_after_stop": null,
+      "stop_order": null
+    },
+    "4": {
+      "obj_type": "srt-xtransmit",
+      "obj_config": {
+        "type": "rcv",
+        "path": "/home/msharabayko/projects/srt/srt-xtransmit/_build/bin/srt-xtransmit",
+        "port": "4200",
+        "attrs_values": [
+          [
+            "transtype",
+            "live"
+          ],
+          [
+            "rcvbuf",
+            "1000000000"
+          ],
+          [
+            "sndbuf",
+            "1000000000"
+          ]
+        ],
+        "options_values": [
+          [
+            "--msgsize",
+            "1316"
+          ]
+        ],
+        "statsdir": "_results",
+        "statsfreq": "100"
+      },
+      "runner_type": "remote-runner",
+      "runner_config": {
+        "username": "msharabayko",
+        "host": "40.69.89.21"
+      },
+      "sleep_after_start": null,
+      "sleep_after_stop": null,
+      "stop_order": null
+    },
+    "5": {
+      "obj_type": "srt-xtransmit",
+      "obj_config": {
+        "type": "snd",
+        "path": "../srt-xtransmit/_build/bin/srt-xtransmit",
+        "port": "4200",
+        "host": "40.69.89.21",
+        "attrs_values": [
+          [
+            "transtype",
+            "live"
+          ],
+          [
+            "rcvbuf",
+            "1000000000"
+          ],
+          [
+            "sndbuf",
+            "1000000000"
+          ]
+        ],
+        "options_values": [
+          [
+            "--msgsize",
+            "1316"
+          ],
+          [
+            "--sendrate",
+            "15Mbps"
+          ],
+          [
+            "--duration",
+            "30"
+          ]
+        ],
+        "statsdir": "_results",
+        "statsfreq": "100"
+      },
+      "runner_type": "local-runner",
+      "runner_config": {},
+      "sleep_after_start": null,
+      "sleep_after_stop": null,
+      "stop_order": null
+    }
+  }
+}

--- a/srt_utils/object_runners.py
+++ b/srt_utils/object_runners.py
@@ -70,7 +70,7 @@ def before_collect_results_checks(
 
     # If an object has filepath equal to None, it means there should be
     # no output file produced
-    if obj.filepath == None:
+    if obj.filepath:
         logger.info('There was no output file expected, nothing to collect')
         return
 
@@ -104,7 +104,6 @@ class IObjectRunner(ABC):
         """
         pass
 
-
     @classmethod
     @abstractmethod
     def from_config(cls, obj: IObject, config: dict):
@@ -121,7 +120,6 @@ class IObjectRunner(ABC):
         """
         pass
 
-
     @abstractmethod
     def start(self):
         """
@@ -132,7 +130,6 @@ class IObjectRunner(ABC):
         """
         pass
 
-
     @abstractmethod
     def stop(self):
         """
@@ -142,7 +139,6 @@ class IObjectRunner(ABC):
             SrtUtilsException
         """
         pass
-
 
     @abstractmethod
     def collect_results(self):
@@ -178,12 +174,10 @@ class LocalRunner(IObjectRunner):
         self.args = self.obj.make_args()
         self.process = Process(self.args)
 
-
     @property
     def status(self):
         status, _ = self.process.status
         return status
-
 
     @staticmethod
     def _create_directory(dirpath: pathlib.Path):
@@ -207,7 +201,6 @@ class LocalRunner(IObjectRunner):
         #         f'create: {dirpath}'
         #     )
 
-
     @classmethod
     def from_config(cls, obj: IObject, config: dict={}):
         """
@@ -221,21 +214,18 @@ class LocalRunner(IObjectRunner):
 
         return cls(obj)
 
-
     def start(self):
         logger.info(f'Starting object on-premises: {self.obj}')
         logger.info(f'Arguments for LocalRunner: {self.obj.make_args()}')
 
-        if self.obj.dirpath != None:
+        if self.obj.dirpath:
             self._create_directory(self.obj.dirpath)
 
         self.process.start()
 
-
     def stop(self):
         logger.info(f'Stopping object on-premises: {self.obj}, {self.process}')
         self.process.stop()
-
 
     def collect_results(self):
         """
@@ -254,7 +244,7 @@ class LocalRunner(IObjectRunner):
         # If an object has filepath defined, it means there should be 
         # an output file produced. However it does not mean that the file
         # was created successfully, that's why we check whether the filepath exists.
-        if self.obj.name != 'netem':
+        if not self.obj.network_condition:
             if not self.obj.filepath.exists():
                 stdout, stderr = self.process.collect_results()
                 raise SrtUtilsException(
@@ -342,12 +332,10 @@ class RemoteRunner(IObjectRunner):
 
         self.process = Process(self.args, True)
 
-
     @property
     def status(self):
         status, _ = self.process.status
         return status
-
 
     @staticmethod
     def _create_directory(
@@ -401,7 +389,6 @@ class RemoteRunner(IObjectRunner):
         if result.exited != 0:
             raise SrtUtilsException(f'Directory has not been created: {dirpath}')
 
-
     @classmethod
     def from_config(cls, obj: IObject, config: dict):
         """
@@ -422,12 +409,11 @@ class RemoteRunner(IObjectRunner):
 
         return cls(obj, config['username'], config['host'])
 
-
     def start(self):
         logger.info(f'Starting object remotely via SSH: {self.obj}')
         logger.info(f'Arguments for RemoteRunner: {self.args}')
 
-        if self.obj.dirpath != None:
+        if self.obj.dirpath:
             self._create_directory(
                 self.obj.dirpath,
                 self.username,
@@ -436,11 +422,9 @@ class RemoteRunner(IObjectRunner):
 
         self.process.start()
 
-
     def stop(self):
         logger.info(f'Stopping object remotely via SSH: {self.obj}, {self.process}')
         self.process.stop()
-
 
     def collect_results(self):
         """

--- a/srt_utils/objects.py
+++ b/srt_utils/objects.py
@@ -135,6 +135,7 @@ class Tshark(IObject):
 
         self.dirpath = pathlib.Path(dirpath)
         self.filepath = self.dirpath / filename
+        self.network_condition = False
 
 
     @classmethod
@@ -253,6 +254,7 @@ class SrtXtransmit(IObject):
         self.attrs_values = attrs_values
         self.options_values = options_values
         self.statsfreq = statsfreq
+        self.network_condition = False
 
         if statsdir is not None:
 
@@ -382,10 +384,10 @@ class Netem(IObject):
 
     def __init__(
             self,
-            # interface: str,
-            # rules: typing.List[str]
-            interface,
-            rules,
+            interface: str,
+            rules: typing.List[str]
+            # interface,
+            # rules,
     ):
 
         super().__init__('netem')
@@ -404,21 +406,15 @@ class Netem(IObject):
 
     def make_args(self):
 
-        return [
-            'sudo',
-            'tc',
-            'qdisc',
-            'add',
-            'dev',
-            self.interface,
-            'root',
-            'netem',
-            # ' '.join(self.rules)
-            'delay',
-            '200ms',
-        ]
+        args = ['sudo', 'tc', 'qdisc', 'add', 'dev', self.interface, 'root', 'netem']
+
+        print(args)
+        for rule in self.rules:
+            args += rule.split(' ')
+        print(args)
+        return args
 
     def make_str(self):
         args = self.make_args()
-        args_str = f'{args[0]} {args[1]} root netem {args[2]}'
+        args_str = ' '.join(args)
         return args_str

--- a/srt_utils/objects.py
+++ b/srt_utils/objects.py
@@ -376,3 +376,49 @@ class SrtXtransmit(IObject):
         args = [f'"{arg}"' if arg.startswith('srt://') else arg for arg in self.make_args()]
         args_str = ' '.join(args)
         return args_str
+
+
+class Netem(IObject):
+
+    def __init__(
+            self,
+            # interface: str,
+            # rules: typing.List[str]
+            interface,
+            rules,
+    ):
+
+        super().__init__('netem')
+        self.filepath = None
+        self.interface = interface
+        self.rules = rules
+        self.network_condition = True
+
+    @classmethod
+    def from_config(cls, config: dict):
+
+        return cls(
+            config['interface'],
+            config['rules']
+        )
+
+    def make_args(self):
+
+        return [
+            'sudo',
+            'tc',
+            'qdisc',
+            'add',
+            'dev',
+            self.interface,
+            'root',
+            'netem',
+            # ' '.join(self.rules)
+            'delay',
+            '200ms',
+        ]
+
+    def make_str(self):
+        args = self.make_args()
+        args_str = f'{args[0]} {args[1]} root netem {args[2]}'
+        return args_str

--- a/srt_utils/objects.py
+++ b/srt_utils/objects.py
@@ -50,11 +50,10 @@ class IObject(ABC):
         # where to store the object results should be present, otherwise it's None.
         self.dirpath = None
         self.filepath = None
-
+        self.network_condition = None
 
     def __str__(self):
         return f'{self.name}'
-
 
     @classmethod
     @abstractmethod
@@ -70,7 +69,6 @@ class IObject(ABC):
         """
         pass
 
-
     @abstractmethod
     def make_args(self):
         """
@@ -79,7 +77,6 @@ class IObject(ABC):
         implemenations.
         """
         pass
-
 
     @abstractmethod
     def make_str(self):
@@ -137,7 +134,6 @@ class Tshark(IObject):
         self.filepath = self.dirpath / filename
         self.network_condition = False
 
-
     @classmethod
     def from_config(cls, config: dict):
         """ 
@@ -176,7 +172,6 @@ class Tshark(IObject):
             '-s', '1500', 
             '-w', str(self.filepath)
         ]
-
 
     def make_str(self):
         """
@@ -270,7 +265,6 @@ class SrtXtransmit(IObject):
             self.dirpath = pathlib.Path(statsdir)
             self.filepath = self.dirpath / filename
 
-
     @classmethod
     def from_config(cls, config: dict):
         """
@@ -308,7 +302,6 @@ class SrtXtransmit(IObject):
             config.get('statsfreq'),
             config.get('prefix')
         )
-
 
     def make_args(self):
         """
@@ -350,7 +343,6 @@ class SrtXtransmit(IObject):
                 args += ['--statsfreq', self.statsfreq]
 
         return args
-
 
     def make_str(self):
         """
@@ -408,10 +400,9 @@ class Netem(IObject):
 
         args = ['sudo', 'tc', 'qdisc', 'add', 'dev', self.interface, 'root', 'netem']
 
-        print(args)
         for rule in self.rules:
             args += rule.split(' ')
-        print(args)
+
         return args
 
     def make_str(self):

--- a/srt_utils/process.py
+++ b/srt_utils/process.py
@@ -36,11 +36,10 @@ class Process:
         self.id = None
         self.is_started = False
         self.is_stopped = False
-
+        self.network_condition = 'netem' in self.args or 'netem' in self.args[-1]
 
     def __str__(self):
         return f'process id {self.id}'
-
 
     @property
     def status(self):
@@ -69,7 +68,6 @@ class Process:
         returncode = self.process.poll()
         status = Status.running if returncode is None else Status.idle
         return (status, returncode)
-
 
     def start(self):
         """
@@ -128,7 +126,7 @@ class Process:
             time.sleep(5)
 
         status, returncode = self.status
-        if status == Status.idle and 'netem' not in self.args:
+        if status == Status.idle and not self.network_condition:
             raise SrtUtilsException(
                 f'Process has not been started: {self.args}, returncode: '
                 f'{returncode}, stdout: {self.process.stdout.readlines()}, '
@@ -136,7 +134,6 @@ class Process:
             )
 
         self.id = self.process.pid
-
 
     def _terminate(self):
         """
@@ -170,7 +167,6 @@ class Process:
 
         raise SrtUtilsException(f'Process has not been terminated: {self.id}')
 
-
     def _kill(self):
         """
         Kill process.
@@ -198,7 +194,6 @@ class Process:
         status, _ = self.status
         if status == Status.running:
             raise SrtUtilsException(f'Process has not been killed: {self.id}')
-
 
     def stop(self):
         """
@@ -255,7 +250,6 @@ class Process:
                 )
 
         self.is_stopped = True
-
 
     def collect_results(self):
         """

--- a/srt_utils/process.py
+++ b/srt_utils/process.py
@@ -128,7 +128,7 @@ class Process:
             time.sleep(5)
 
         status, returncode = self.status
-        if status == Status.idle:
+        if status == Status.idle and 'netem' not in self.args:
             raise SrtUtilsException(
                 f'Process has not been started: {self.args}, returncode: '
                 f'{returncode}, stdout: {self.process.stdout.readlines()}, '

--- a/srt_utils/runners.py
+++ b/srt_utils/runners.py
@@ -25,6 +25,8 @@ class SimpleFactory:
             obj = objects.Tshark.from_config(obj_config)
         elif obj_type == 'srt-xtransmit':
             obj = objects.SrtXtransmit.from_config(obj_config)
+        elif obj_type == 'netem':
+            obj = objects.Netem.from_config(obj_config)
         else:
             print('No matching object found')
 

--- a/srt_utils/runners.py
+++ b/srt_utils/runners.py
@@ -18,7 +18,8 @@ logger = logging.getLogger(__name__)
 
 class SimpleFactory:
 
-    def create_object(self, obj_type: str, obj_config: dict) -> objects.IObject:
+    @staticmethod
+    def create_object(obj_type: str, obj_config: dict) -> objects.IObject:
         obj = None
 
         if obj_type == 'tshark':
@@ -32,7 +33,8 @@ class SimpleFactory:
 
         return obj
 
-    def create_runner(self, obj, runner_type: str, runner_config: dict) -> object_runners.IObjectRunner:
+    @staticmethod
+    def create_runner(obj, runner_type: str, runner_config: dict) -> object_runners.IObjectRunner:
         runner = None
 
         if runner_type == 'local-runner':
@@ -98,7 +100,6 @@ class Task:
         self.sleep_after_stop = config.get('sleep_after_stop')
         self.stop_order = config.get('stop_order')
 
-
     def __str__(self):
         return f'task-{self.key}'
 
@@ -150,7 +151,6 @@ class SingleExperimentRunner:
 
         # self.log = ContextualLoggerAdapter(LOGGER, {'context': type(self).__name__})
 
-
     @staticmethod
     def _create_directory(dirpath: pathlib.Path):
         """
@@ -174,7 +174,6 @@ class SingleExperimentRunner:
                 'will not be deleted'
             )
 
-
     @classmethod
     def from_config(cls, config: dict):
         """
@@ -191,7 +190,6 @@ class SingleExperimentRunner:
             config['stop_after'],
             config['tasks'].items()
         )
-
 
     def start(self):
         """
@@ -219,7 +217,6 @@ class SingleExperimentRunner:
                 time.sleep(sleep_after_start)
 
         self.is_started = True
-
 
     def stop(self):
         """
@@ -267,7 +264,6 @@ class SingleExperimentRunner:
 
         self.is_stopped = True
 
-
     def collect_results(self):
         """
         Collect experiment results.
@@ -300,7 +296,6 @@ class SingleExperimentRunner:
                     f'Failed to collect task results: {task}. Reason: {error}'
                 )
                 continue
-
 
     def clean_up(self):
         """


### PR DESCRIPTION
This PR adds the functionality of using a network emulator (tc-netem) on the experiments by means of an additional type of task in the config files.

This works both on local and remote runners. 

There are some cool features that could be introduced later, but will require more 'heavy' changes in the code. I will just list them and after the feedback we can discuss the implementation and the direction we want to take.

* Automatic cleanse of the network conditions.
* Be able to do a schedule on the network conditions, something like: run 15 seconds without any conditions, then add 50 ms delay and 10% packet loss, then clear the conditions and go back to normal.