### PR TITLE
Fixed fabric version to solve the issue when copying remote files

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 install_requires = [
     'attrs',
     'click >=7.0,<8.0',
-    'fabric',
+    'fabric <=2.5.0',
     'paramiko',
     'patchwork'
 ]


### PR DESCRIPTION
Fixed the version of fabric in `setup.py` which caused some undesired behaviour when collecting task results. Closes issue #36. 